### PR TITLE
Update internal callback to use on prefix

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,15 +18,12 @@ class ImportantJob < ApplicationJob
   queue_as :default
 
   add_contract JobContracts::DurationContract.new(duration: 5.seconds)
-  after_contract_breach :contract_breached
 
   def perform
     # logic...
   end
 
-  private
-
-  def contract_breached(contract)
+  def contract_breached!(contract)
     # log and notify apm/monitoring service
   end
 end
@@ -66,16 +63,13 @@ class FastJob < ApplicationJob
 
   # NOTE: the ReadOnlyContract only enforces on the queue configured above
   add_contract JobContracts::ReadOnlyContract.new
-  after_contract_breach :contract_breached
 
   def perform(contracts_to_skip=nil)
     # logic that shouldn't write to the database,
     # but might accidentally due to complex or opaque internals
   end
 
-  private
-
-  def contract_breached(contract)
+  def contract_breached!(contract)
     # log and notify apm/monitoring service
 
     # re-enqueue to the queue expected by the contract

--- a/lib/job_contracts/contracts/contract.rb
+++ b/lib/job_contracts/contracts/contract.rb
@@ -8,9 +8,10 @@ module JobContracts
 
     attr_reader :trigger
 
-    def initialize(trigger: :after, halt: false, **kwargs)
+    def initialize(trigger: :after, halt: false, enforce_on_all_queues: false, **kwargs)
       @trigger = trigger.to_sym
       @halt = halt
+      @enforce_on_all_queues = enforce_on_all_queues
       expected.merge! kwargs
     end
 
@@ -22,11 +23,17 @@ module JobContracts
       @actual ||= HashWithIndifferentAccess.new
     end
 
+    def should_enforce?
+      return true if enforce_on_all_queues?
+      actual[:queue_name] == expected[:queue_name]
+    end
+
     # Method to be implemented by subclasses
     # NOTE: subclasses should update `actual`, set `satisfied`, and call `super`
     def enforce!(contractable)
-      actual[:queue_name] = contractable.queue_name
-      add_observer contractable, :after_contract_breach
+      actual[:queue_name] = contractable.queue_name.to_s
+      return unless should_enforce?
+      add_observer contractable, :on_contract_breach
       changed if breached?
       notify_observers self
     ensure
@@ -43,6 +50,10 @@ module JobContracts
 
     def halt?
       !!@halt
+    end
+
+    def enforce_on_all_queues?
+      !!@enforce_on_all_queues
     end
 
     def before?

--- a/lib/job_contracts/contracts/queue_name_contract.rb
+++ b/lib/job_contracts/contracts/queue_name_contract.rb
@@ -5,11 +5,11 @@ require_relative "contract"
 module JobContracts
   class QueueNameContract < Contract
     def initialize
-      super trigger: :before, halt: true
+      super trigger: :before, halt: true, enforce_on_all_queues: true
     end
 
     def enforce!(contractable)
-      self.satisfied = contractable.queue_name.to_s == expected[:queue_name].to_s
+      self.satisfied = contractable.queue_name.to_s == expected[:queue_name]
       super
     end
   end

--- a/lib/job_contracts/contracts/read_only_contract.rb
+++ b/lib/job_contracts/contracts/read_only_contract.rb
@@ -9,7 +9,7 @@ module JobContracts
 
       def perform(*args)
         contract = contracts.find { |c| c.is_a?(ReadOnlyContract) }
-        if contract.expected[:queue_name].to_s == queue_name.to_s
+        if queue_name.to_s == contract.expected[:queue_name]
           ActiveRecord::Base.while_preventing_writes do
             super
           end

--- a/test/dummy/app/jobs/duration_example_job.rb
+++ b/test/dummy/app/jobs/duration_example_job.rb
@@ -6,15 +6,12 @@ class DurationExampleJob < ApplicationJob
   queue_as :default
 
   add_contract JobContracts::DurationContract.new(duration: 1.second)
-  after_contract_breach :contract_breached
 
   def perform
     sleep 2
   end
 
-  private
-
-  def contract_breached(contract)
+  def contract_breached!(contract)
     # log and notify apm/monitoring service
     Rails.logger.info "Contract breached! #{contract.inspect}"
   end

--- a/test/dummy/app/jobs/multiple_contracts_example_job.rb
+++ b/test/dummy/app/jobs/multiple_contracts_example_job.rb
@@ -9,16 +9,12 @@ class MultipleContractsExampleJob < ApplicationJob
   add_contract JobContracts::DurationContract.new(duration: 1.second)
   add_contract JobContracts::ReadOnlyContract.new
 
-  after_contract_breach :contract_breached
-
   def perform
     sleep 2
     User.create! name: "test"
   end
 
-  private
-
-  def contract_breached(contract)
+  def contract_breached!(contract)
     # log and notify apm/monitoring service
     Rails.logger.info "Contract breached! #{contract.inspect}"
 

--- a/test/dummy/app/jobs/queue_name_example_job.rb
+++ b/test/dummy/app/jobs/queue_name_example_job.rb
@@ -6,15 +6,12 @@ class QueueNameExampleJob < ApplicationJob
   queue_as :low
 
   add_contract JobContracts::QueueNameContract.new
-  after_contract_breach :contract_breached
 
   def perform(*args)
     Rails.logger.info "Actually performed on: #{queue_name}"
   end
 
-  private
-
-  def contract_breached(contract)
+  def contract_breached!(contract)
     # log and notify apm/monitoring service
     Rails.logger.info "Contract breached! #{contract.inspect}"
 

--- a/test/dummy/app/jobs/read_only_example_job.rb
+++ b/test/dummy/app/jobs/read_only_example_job.rb
@@ -6,15 +6,12 @@ class ReadOnlyExampleJob < ApplicationJob
   queue_as :default
 
   add_contract JobContracts::ReadOnlyContract.new
-  after_contract_breach :contract_breached
 
   def perform
     User.create! name: "test"
   end
 
-  private
-
-  def contract_breached(contract)
+  def contract_breached!(contract)
     # log and notify apm/monitoring service
     Rails.logger.info "Contract breached! #{contract.inspect}"
   end

--- a/test/dummy/app/sidekiq/duration_example_sidekiq_job.rb
+++ b/test/dummy/app/sidekiq/duration_example_sidekiq_job.rb
@@ -7,15 +7,12 @@ class DurationExampleSidekiqJob
   sidekiq_options queue: :default
 
   add_contract JobContracts::DurationContract.new(duration: 1.second)
-  after_contract_breach :contract_breached
 
   def perform
     sleep 2
   end
 
-  private
-
-  def contract_breached(contract)
+  def contract_breached!(contract)
     # log and notify apm/monitoring service
     Rails.logger.info "Contract breached! #{contract.inspect}"
   end

--- a/test/dummy/app/sidekiq/multiple_contracts_example_sidekiq_job.rb
+++ b/test/dummy/app/sidekiq/multiple_contracts_example_sidekiq_job.rb
@@ -9,16 +9,13 @@ class MultipleContractsExampleSidekiqJob
   add_contract JobContracts::QueueNameContract.new
   add_contract JobContracts::DurationContract.new(duration: 1.second)
   add_contract JobContracts::ReadOnlyContract.new
-  after_contract_breach :contract_breached
 
   def perform
     sleep 2
     User.create! name: "test"
   end
 
-  private
-
-  def contract_breached(contract)
+  def contract_breached!(contract)
     # log and notify apm/monitoring service
     Rails.logger.info "Contract breached! #{contract.inspect}"
 

--- a/test/dummy/app/sidekiq/queue_name_example_sidekiq_job.rb
+++ b/test/dummy/app/sidekiq/queue_name_example_sidekiq_job.rb
@@ -7,15 +7,12 @@ class QueueNameExampleSidekiqJob
   sidekiq_options queue: :low
 
   add_contract JobContracts::QueueNameContract.new
-  after_contract_breach :contract_breached
 
   def perform
     Rails.logger.info "Actually performed on: #{queue_name}"
   end
 
-  private
-
-  def contract_breached(contract)
+  def contract_breached!(contract)
     # log and notify apm/monitoring service
     Rails.logger.info "Contract breached! #{contract.inspect}"
 

--- a/test/dummy/app/sidekiq/read_only_example_sidekiq_job.rb
+++ b/test/dummy/app/sidekiq/read_only_example_sidekiq_job.rb
@@ -7,15 +7,12 @@ class ReadOnlyExampleSidekiqJob
   sidekiq_options queue: :low
 
   add_contract JobContracts::ReadOnlyContract.new
-  after_contract_breach :contract_breached
 
   def perform
     User.create! name: "test"
   end
 
-  private
-
-  def contract_breached(contract)
+  def contract_breached!(contract)
     # log and notify apm/monitoring service
     Rails.logger.info "Contract breached! #{contract.inspect}"
   end

--- a/test/jobs/queue_name_example_job_test.rb
+++ b/test/jobs/queue_name_example_job_test.rb
@@ -17,9 +17,9 @@ class QueueNameExampleJobTest < ActiveJob::TestCase
     breached_contracts = job.breached_contracts.to_a
     assert breached_contracts.size == 1
     assert breached_contracts.first.breached?
-    assert breached_contracts.first.expected[:queue_name].to_sym == :low
-    assert breached_contracts.first.actual[:queue_name].to_sym == :default
+    assert breached_contracts.first.expected[:queue_name] == "low"
+    assert breached_contracts.first.actual[:queue_name] == "default"
     assert job.enqueues.size == 1
-    assert job.enqueues.first[:queue] == :low
+    assert job.enqueues.first[:queue] == "low"
   end
 end


### PR DESCRIPTION
Also setup default callback so consumers only need to define the method if desired. Overrides are still possible.